### PR TITLE
Use randomBytes instead of pseudoRandomBytes

### DIFF
--- a/build/register.js
+++ b/build/register.js
@@ -17,7 +17,7 @@ crypto = require('crypto');
  */
 
 exports.generateUUID = function() {
-  return crypto.pseudoRandomBytes(31).toString('hex');
+  return crypto.randomBytes(31).toString('hex');
 };
 
 

--- a/lib/register.coffee
+++ b/lib/register.coffee
@@ -19,7 +19,7 @@ exports.generateUUID = ->
 	# pass the certificate validation in OpenVPN This either means that
 	# the RFC counts a final NULL byte as part of the CN or that the
 	# OpenVPN/OpenSSL implementation has a bug.
-	return crypto.pseudoRandomBytes(31).toString('hex')
+	return crypto.randomBytes(31).toString('hex')
 
 ###*
 # @summary Register a device with Resin.io


### PR DESCRIPTION
Using `randomBytes` increases the strength of the uuid and reduces the
chances of collisions.

Fixes: https://github.com/resin-io/resin-register-device/issues/4