### PR TITLE
generateUUID with randomBytes and using promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Generate a random UUID.
 
 Example:
 ```coffee
-deviceRegister.generateUUID (err, uuid) ->
-	throw err if err?
+deviceRegister.generateUUID (error, uuid) ->
+	throw error if error?
 	# uuid is a generated UUID that can be used for registering
 	console.log(uuid)
 ```

--- a/README.md
+++ b/README.md
@@ -24,11 +24,14 @@ Documentation
 
 Generate a random UUID.
 
-Example:
+**Notice**: You can use this function as a promise if you omit the `callback` argument.
 
+Example:
 ```coffee
-deviceRegister = require('resin-register-device')
-uuid = deviceRegister.generateUUID()
+deviceRegister.generateUUID (err, uuid) ->
+	throw err if err?
+	# uuid is a generated UUID that can be used for registering
+	console.log(uuid)
 ```
 
 ### deviceRegister.register(Object pineInstance, Object options, Function callback)

--- a/build/register.js
+++ b/build/register.js
@@ -1,4 +1,6 @@
-var crypto, _;
+var Promise, crypto, _;
+
+Promise = require('bluebird');
 
 _ = require('lodash');
 
@@ -10,14 +12,26 @@ crypto = require('crypto');
  * @function
  * @public
  *
- * @returns {String} A generated UUID
+ * @description
+ * This function allows promise style if the callback is omitted.
+ *
+ * @param {Function} callback - callback (error, uuid)
  *
  * @example
- * uuid = register.generateUUID()
+ * deviceRegister.generateUUID (err, uuid) ->
+ * 	throw err if err?
+ *	# uuid is a generated UUID that can be used for registering
+ * 	console.log(uuid)
  */
 
-exports.generateUUID = function() {
-  return crypto.pseudoRandomBytes(31).toString('hex');
+exports.generateUUID = function(callback) {
+  return Promise["try"](function() {
+    return crypto.randomBytes(31).toString('hex');
+  })["catch"](function() {
+    return Promise.delay(1).then(function() {
+      return exports.generateUUID();
+    });
+  }).nodeify(callback);
 };
 
 
@@ -52,17 +66,21 @@ exports.generateUUID = function() {
  */
 
 exports.register = function(pineInstance, options, callback) {
-  return pineInstance.post({
-    resource: 'device',
-    body: {
-      user: options.userId,
-      application: options.applicationId,
-      uuid: options.uuid || exports.generateUUID(),
-      device_type: options.deviceType,
-      registered_at: Math.floor(Date.now() / 1000)
-    },
-    customOptions: {
-      apikey: options.apiKey
-    }
+  return Promise["try"](function() {
+    return options.uuid || exports.generateUUID();
+  }).then(function(uuid) {
+    return pineInstance.post({
+      resource: 'device',
+      body: {
+        user: options.userId,
+        application: options.applicationId,
+        uuid: uuid,
+        device_type: options.deviceType,
+        registered_at: Math.floor(Date.now() / 1000)
+      },
+      customOptions: {
+        apikey: options.apiKey
+      }
+    });
   }).nodeify(callback);
 };

--- a/build/register.js
+++ b/build/register.js
@@ -18,8 +18,8 @@ crypto = require('crypto');
  * @param {Function} callback - callback (error, uuid)
  *
  * @example
- * deviceRegister.generateUUID (err, uuid) ->
- * 	throw err if err?
+ * deviceRegister.generateUUID (error, uuid) ->
+ * 	throw error if error?
  *	# uuid is a generated UUID that can be used for registering
  * 	console.log(uuid)
  */
@@ -28,9 +28,7 @@ exports.generateUUID = function(callback) {
   return Promise["try"](function() {
     return crypto.randomBytes(31).toString('hex');
   })["catch"](function() {
-    return Promise.delay(1).then(function() {
-      return exports.generateUUID();
-    });
+    return Promise.delay(1).then(exports.generateUUID);
   }).nodeify(callback);
 };
 

--- a/lib/register.coffee
+++ b/lib/register.coffee
@@ -1,3 +1,4 @@
+Promise = require('bluebird')
 _ = require('lodash')
 crypto = require('crypto')
 
@@ -6,12 +7,18 @@ crypto = require('crypto')
 # @function
 # @public
 #
-# @returns {String} A generated UUID
+# @description
+# This function allows promise style if the callback is omitted.
+#
+# @param {Function} callback - callback (error, uuid)
 #
 # @example
-# uuid = register.generateUUID()
+# deviceRegister.generateUUID (err, uuid) ->
+# 	throw err if err?
+#	# uuid is a generated UUID that can be used for registering
+# 	console.log(uuid)
 ###
-exports.generateUUID = ->
+exports.generateUUID = (callback) ->
 
 	# I'd be nice if the UUID matched the output of a SHA-256 function,
 	# but although the length limit of the CN attribute in a X.509
@@ -19,7 +26,12 @@ exports.generateUUID = ->
 	# pass the certificate validation in OpenVPN This either means that
 	# the RFC counts a final NULL byte as part of the CN or that the
 	# OpenVPN/OpenSSL implementation has a bug.
-	return crypto.pseudoRandomBytes(31).toString('hex')
+	Promise.try ->
+		crypto.randomBytes(31).toString('hex')
+	.catch ->
+		Promise.delay(1).then ->
+			exports.generateUUID()
+	.nodeify(callback)
 
 ###*
 # @summary Register a device with Resin.io
@@ -51,16 +63,18 @@ exports.generateUUID = ->
 #		console.log(device)
 ###
 exports.register = (pineInstance, options, callback) ->
-	pineInstance.post
-		resource: 'device'
-		body:
-			user: options.userId
-			application: options.applicationId
-			uuid: options.uuid or exports.generateUUID()
-			device_type: options.deviceType
-			registered_at: Math.floor(Date.now() / 1000)
-		customOptions:
-			apikey: options.apiKey
-
+	Promise.try ->
+		options.uuid or exports.generateUUID()
+	.then (uuid) ->
+		pineInstance.post
+			resource: 'device'
+			body:
+				user: options.userId
+				application: options.applicationId
+				uuid: uuid
+				device_type: options.deviceType
+				registered_at: Math.floor(Date.now() / 1000)
+			customOptions:
+				apikey: options.apiKey
 	# Allow promise based and callback based styles
 	.nodeify(callback)

--- a/lib/register.coffee
+++ b/lib/register.coffee
@@ -13,8 +13,8 @@ crypto = require('crypto')
 # @param {Function} callback - callback (error, uuid)
 #
 # @example
-# deviceRegister.generateUUID (err, uuid) ->
-# 	throw err if err?
+# deviceRegister.generateUUID (error, uuid) ->
+# 	throw error if error?
 #	# uuid is a generated UUID that can be used for registering
 # 	console.log(uuid)
 ###
@@ -29,8 +29,7 @@ exports.generateUUID = (callback) ->
 	Promise.try ->
 		crypto.randomBytes(31).toString('hex')
 	.catch ->
-		Promise.delay(1).then ->
-			exports.generateUUID()
+		Promise.delay(1).then(exports.generateUUID)
 	.nodeify(callback)
 
 ###*
@@ -64,7 +63,7 @@ exports.generateUUID = (callback) ->
 ###
 exports.register = (pineInstance, options, callback) ->
 	Promise.try ->
-		options.uuid or exports.generateUUID()
+		return options.uuid or exports.generateUUID()
 	.then (uuid) ->
 		pineInstance.post
 			resource: 'device'

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "author": "Juan Cruz Viotti <juanchiviotti@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "bluebird": "^2.9.26",
     "chai": "^2.3.0",
     "chai-as-promised": "^5.0.0",
     "coffee-script": "~1.8.0",
@@ -37,6 +36,7 @@
     "sinon-chai": "~2.7.0"
   },
   "dependencies": {
+    "bluebird": "^2.9.26",
     "lodash": "^3.5.0"
   }
 }

--- a/tests/register.spec.coffee
+++ b/tests/register.spec.coffee
@@ -11,22 +11,32 @@ describe 'Device Register:', ->
 
 	describe '.generateUUID()', ->
 
-		it 'should return a string', ->
-			uuid = register.generateUUID()
-			expect(uuid).to.be.a('string')
+		it 'should return a string in its callback', (done) ->
+			register.generateUUID (err, uuid) ->
+				expect(uuid).to.be.a('string')
+				done()
 
-		it 'should have a length of 62 (31 bytes)', ->
-			uuid = register.generateUUID()
-			expect(uuid).to.have.length(62)
+		it 'should return a string if called in Promise mode', (done) ->
+			register.generateUUID()
+			.then (uuid) ->
+				expect(uuid).to.be.a('string')
+				done()
 
-		it 'should generate different uuids each time', ->
-			uuid1 = register.generateUUID()
-			uuid2 = register.generateUUID()
-			uuid3 = register.generateUUID()
+		it 'should have a length of 62 (31 bytes)', (done) ->
+			register.generateUUID (err, uuid) ->
+				expect(uuid).to.have.length(62)
+				done()
 
-			expect(uuid1).to.not.equal(uuid2)
-			expect(uuid2).to.not.equal(uuid3)
-			expect(uuid3).to.not.equal(uuid1)
+		it 'should generate different uuids each time', (done) ->
+			Promise.all([
+				register.generateUUID()
+				register.generateUUID()
+				register.generateUUID()
+			]).then ([ uuid1, uuid2, uuid3 ]) ->
+				expect(uuid1).to.not.equal(uuid2)
+				expect(uuid2).to.not.equal(uuid3)
+				expect(uuid3).to.not.equal(uuid1)
+				done()
 
 	describe '.register()', ->
 
@@ -106,7 +116,7 @@ describe 'Device Register:', ->
 
 			describe 'given a explicit uuid', ->
 
-				it 'should call pineInstance.post() with that uuid', ->
+				it 'should call pineInstance.post() with that uuid', (done) ->
 					postSpy = sinon.spy(@pineInstance, 'post')
 
 					register.register @pineInstance,
@@ -115,15 +125,15 @@ describe 'Device Register:', ->
 						deviceType: 'raspberry-pi'
 						uuid: 'asdf'
 						apiKey: 'asdf'
-					, _.noop
-
-					expect(postSpy).to.have.been.calledOnce
-					expect(postSpy.args[0][0].body.uuid).to.equal('asdf')
-					postSpy.restore()
+					, ->
+						expect(postSpy).to.have.been.calledOnce
+						expect(postSpy.args[0][0].body.uuid).to.equal('asdf')
+						postSpy.restore()
+						done()
 
 			describe 'given no uuid', ->
 
-				it 'should call pineInstance.post() with a generated uuid', ->
+				it 'should call pineInstance.post() with a generated uuid', (done) ->
 					postSpy = sinon.spy(@pineInstance, 'post')
 
 					register.register @pineInstance,
@@ -131,9 +141,9 @@ describe 'Device Register:', ->
 						applicationId: 10350
 						deviceType: 'raspberry-pi'
 						apiKey: 'asdf'
-					, _.noop
-
-					expect(postSpy).to.have.been.calledOnce
-					expect(postSpy.args[0][0].body.uuid).to.exist
-					expect(postSpy.args[0][0].body.uuid).to.have.length(62)
-					postSpy.restore()
+					, ->
+						expect(postSpy).to.have.been.calledOnce
+						expect(postSpy.args[0][0].body.uuid).to.exist
+						expect(postSpy.args[0][0].body.uuid).to.have.length(62)
+						postSpy.restore()
+						done()


### PR DESCRIPTION
This PR switches the use of crypto.pseudoRandomBytes to crypto.randomBytes, ensuring cryptographically secure UUIDs.
Since randomBytes can throw an exception, we make generateUUID() asynchronous so that we can catch it and retry.