### PR TITLE
Prevent error infinite loop when generating a UUID

### DIFF
--- a/build/register.js
+++ b/build/register.js
@@ -43,8 +43,11 @@ crypto = require('crypto');
 exports.generateUUID = function(callback) {
   return Promise["try"](function() {
     return crypto.randomBytes(31).toString('hex');
-  })["catch"](function() {
-    return Promise.delay(1).then(exports.generateUUID);
+  })["catch"](function(error) {
+    if (error.message === 'Not enough entropy') {
+      return Promise.delay(1).then(exports.generateUUID);
+    }
+    throw error;
   }).nodeify(callback);
 };
 

--- a/lib/register.coffee
+++ b/lib/register.coffee
@@ -44,8 +44,10 @@ exports.generateUUID = (callback) ->
 	# OpenVPN/OpenSSL implementation has a bug.
 	Promise.try ->
 		crypto.randomBytes(31).toString('hex')
-	.catch ->
-		Promise.delay(1).then(exports.generateUUID)
+	.catch (error) ->
+		if error.message is 'Not enough entropy'
+			return Promise.delay(1).then(exports.generateUUID)
+		throw error
 	.nodeify(callback)
 
 ###*

--- a/tests/register.spec.coffee
+++ b/tests/register.spec.coffee
@@ -21,6 +21,12 @@ describe 'Device Register:', ->
 		it 'should return a string if called in Promise mode', ->
 			expect(register.generateUUID()).to.eventually.be.a('string')
 
+		it 'should not retry if there is an error other than "not enough entropy"', ->
+			stub = sinon.stub(crypto, 'randomBytes')
+			stub.throws(new Error('Unknown error'))
+			expect(register.generateUUID()).to.be.rejectedWith('Unknown error')
+			stub.restore()
+
 		it 'should return a string even if randomBytes throws a few times', (done) ->
 			sinon.stub crypto, 'randomBytes', do ->
 				_nCalls = 0


### PR DESCRIPTION
Currently, we run `crypto.randomBytes(31).toString('hex')`, and if such
function throws any error, we wait for a millisecond and retry in order
to cope with low entropy situations.

The issue is that if the function above throws an error unrelated to
entropy, like:

	secure random number generation not supported by this browser use chrome, FireFox or Internet Explorer 11

which happens when running this function on IE 10, an infinite loop
occurs.